### PR TITLE
SalesForce returns blank string for empty decimal field

### DIFF
--- a/SalesforceMagic/Extensions/TypeExtensions.cs
+++ b/SalesforceMagic/Extensions/TypeExtensions.cs
@@ -94,7 +94,10 @@ namespace SalesforceMagic.Extensions
         {
             try
             {
-                return Convert.ToDouble(value);
+                if (String.IsNullOrEmpty(value))
+                    return 0.0;
+                else
+                    return Convert.ToDouble(value);
             }
             catch (FormatException e) { throw new SalesforceRequestException(e.Message); }
         }


### PR DESCRIPTION
ToDouble failed to parse "" as 0.